### PR TITLE
Document and warn about ignored registration requests, closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Some setup is required the first time the service is launched:
 
 When the service starts it broadcasts UDP traffic to find the Lightwave Link on your network.
 
-The first time this happens the Lightwave Link will respond with a "Not registered" error, indicating it does not recognise the MAC address of your host as authorised to issue commands to it. The service responds to this error by attempting to register with the Lightwave Link (... in an endless loop!). The Lightwave Link's one and only button will begin flashing its LED - go push it to authorise the MAC address of your host to issue commands.
+The first time this happens the Lightwave Link will respond with a "Not registered" error, indicating it does not recognise the MAC address of your host as authorised to issue commands to it. The service responds to this error by attempting to register with the Lightwave Link (... in an endless loop!). The Lightwave Link's one and only button should begin flashing its LED - go push it to authorise the MAC address of your host to issue commands.
+
+If there are already 12 devices registered with the Lightwave Link, new registration requests will be ignored. To register a new device, you will need to use an existing device to de-authorise all existing devices and reconnect only the ones you are using.
 
 If all is well, the service will log the following:
 

--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,19 @@
 #
 #   $SERIAL_STR: $NAME_STR
 #
+# Notes
+#
+#   1. Serial strings should all be 6 characters long, excluding quotes
+#   2. Serial strings which are only numbers should be enclosed in quotes
+#   3. Numeric serial strings which start with a zero MUST be quoted
+#
+# Examples
+#
+# 1A2B3C:Device with unquoted serial string
+# '1A2B3C':Device with quoted serial string
+# '123456':Device with numeric serial string
+# '012345':Device with numeric serial string with leading zero
+#
 9993FE: Boiler switch
 5FC502: Lounge
 DBC302: Playroom

--- a/lightwave_link.py
+++ b/lightwave_link.py
@@ -581,6 +581,23 @@ def load_config():
     import yaml
     with file("config.yml", "r") as sFH:
         dConfig = yaml.load(sFH)
+
+    numeric_serials=[key for key in dConfig.keys() if key != str(key)]
+    if numeric_serials:
+        sLog.info(
+            "Found numeric serial strings %r in config file, attempting fix",
+            numeric_serials)
+        dConfig={str(key):value for (key,value) in dConfig.iteritems()}
+        sLog.debug("Config: %r",dConfig)
+
+    invalid_serials=[key for key in dConfig.keys() if len(key) != 6]
+    if invalid_serials:
+        sLog.warn(
+            "Found invalid serial strings %r in config file",
+            invalid_serials)
+        sLog.info("* Ensure serial strings are all 6 characters long")
+        sLog.info("* Enclose serial strings starting with a 0 in quotes")
+
     return dConfig
 
 def call_for_heat(sLink, dStatus):

--- a/lightwave_link.py
+++ b/lightwave_link.py
@@ -313,6 +313,14 @@ class LightwaveLink(object):
                         "Pairing request sent. Please push button with "
                         "flashing light on Lightwave Link to complete "
                         "pairing. (Or press ^C to give up)")
+                    sLog.info(
+                        "If the light on the Lightwave Link does not flash, "
+                        "you may already have the maximum 12 devices "
+                        "registered with it.")
+                    sLog.info(
+                        "To fix this you will need to use a device already "
+                        "registered with the Link to de-authorise all devices "
+                        "and individually re-authorise them.")
                     time.sleep(3)
                 elif dResponse.get("msg") == "success":
                     sLog.info("Successfully paired!")


### PR DESCRIPTION
Sadly you only get to find out that a there are too many devices registered by the absence of a response to the registration request. You don't get to find out how many devices are registered until you are registered yourself, so the best we can do is document this and warn about the possibility.